### PR TITLE
Emit Proposals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,5 @@ test-lusd-v3-ethereum :; forge test -vvv --match-contract AaveV3EthLUSDPayloadTe
 mai-payload :;  forge script script/DeployMaiPolygonPayload.s.sol:MAI --rpc-url ${RPC_POLYGON}  --broadcast --legacy --ledger --mnemonic-indexes ${MNEMONIC_INDEX} --sender ${LEDGER_SENDER} --verify --etherscan-api-key ${ETHERSCAN_API_KEY_POLYGON} -vvvv
 
 test-mai-payload :; forge test -vvv --match-contract MAIV3PolCapsPayloadTest
+
+emit-mainnet-proposal :; forge script script/EmitMainnetProposal.s.sol:EmitDeployAllCaps

--- a/script/EmitMainnetProposal.s.sol
+++ b/script/EmitMainnetProposal.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+import {GovHelpers} from 'aave-helpers/GovHelpers.sol';
+import {Script} from 'forge-std/Script.sol';
+import {Test} from 'forge-std/Test.sol';
+import {AaveGovernanceV2, IExecutorWithTimelock} from 'aave-address-book/AaveGovernanceV2.sol';
+
+library EmitDeployMutliChainProposals {
+  function _deployL1Proposal(
+    address[] memory payloads,
+    address[] memory targets,
+    bytes32 ipfsHash
+  ) internal pure returns (bytes memory callData) {
+    require(ipfsHash != bytes32(0), "ERROR: IPFS_HASH can't be 0");
+    require(targets.length == payloads.length, 'ERROR: array length mismatch');
+
+    uint256[] memory values = new uint256[](payloads.length);
+    string[] memory signatures = new string[](payloads.length);
+    bytes[] memory calldatas = new bytes[](payloads.length);
+    bool[] memory withDelegatecalls = new bool[](payloads.length);
+    for (uint256 i = 0; i < payloads.length; i++) {
+      require(payloads[i] != address(0), "ERROR: PAYLOAD can't be address(0)");
+      require(targets[i] != address(0), "ERROR: target can't be address(0)");
+      values[i] = 0;
+      signatures[i] = 'execute(address)';
+      calldatas[i] = abi.encode(payloads[i]);
+      withDelegatecalls[i] = true;
+    }
+
+    return
+      abi.encodeWithSelector(
+        AaveGovernanceV2.GOV.create.selector,
+        IExecutorWithTimelock(AaveGovernanceV2.SHORT_EXECUTOR),
+        targets,
+        values,
+        signatures,
+        calldatas,
+        withDelegatecalls,
+        ipfsHash
+      );
+  }
+}
+
+contract EmitDeployAllCaps is Script, Test {
+  function run() external {
+    address[] memory payloads = new address[](2);
+    address[] memory targets = new address[](2);
+
+    //Borrow caps payloads:
+    payloads[0] = 0x060Bea15AF594FE9e0A243cA632F2C7D1935C70f; // polygon
+    targets[0] = AaveGovernanceV2.CROSSCHAIN_FORWARDER_POLYGON;
+
+    payloads[1] = 0x280e404338d9d8e50B11D6677B9C91BA86E0FD22; // arbitrum
+    targets[1] = AaveGovernanceV2.CROSSCHAIN_FORWARDER_ARBITRUM;
+
+    bytes memory callData = EmitDeployMutliChainProposals._deployL1Proposal(
+      payloads,
+      targets,
+      0x6398bf1320d1347de159e8e387962ca4478d324c1b0664f7ea9afe2cbafa5e21
+    );
+    emit log_bytes(callData);
+  }
+}


### PR DESCRIPTION
A script to emit the mainnet proposal payload in case where Gnosis is used to trigger

Test:

```
[aave-proposals] # make emit-mainnet-proposal
Makefile:67: warning: overriding commands for target `lusd-strategy'
Makefile:63: warning: ignoring old commands for target `lusd-strategy'
Makefile:69: warning: overriding commands for target `test-lusd-v3-ethereum'
Makefile:65: warning: ignoring old commands for target `test-lusd-v3-ethereum'
forge script script/EmitMainnetProposal.s.sol:EmitDeployAllCaps
[⠒] Compiling...
No files changed, compilation skipped
Script ran successfully.
Gas used: 39159

== Logs ==
  0xf8741a9c000000000000000000000000ee56e2b3d491590b5b31738cc34d5232f378a8d500000000000000000000000000000000000000000000000000000000000000e0000000000000000000000000000000000000000000000000000000000000014000000000000000000000000000000000000000000000000000000000000001a0000000000000000000000000000000000000000000000000000000000000028000000000000000000000000000000000000000000000000000000000000003606398bf1320d1347de159e8e387962ca4478d324c1b0664f7ea9afe2cbafa5e210000000000000000000000000000000000000000000000000000000000000002000000000000000000000000158a6bc04f0828318821bae797f50b0a1299d45b0000000000000000000000002e2b1f112c4d79a9d22464f0d345de9b792705f100000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000106578656375746528616464726573732900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001065786563757465286164647265737329000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000020000000000000000000000000060bea15af594fe9e0a243ca632f2c7d1935c70f0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000280e404338d9d8e50b11d6677b9c91ba86e0fd22000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001
```