### PR TITLE
Add stMatic Polygon Supply Cap to Existing Payload

### DIFF
--- a/src/contracts/polygon/AaveV3PolCapsPayload-Feb26.sol
+++ b/src/contracts/polygon/AaveV3PolCapsPayload-Feb26.sol
@@ -12,15 +12,17 @@ import {IProposalGenericExecutor} from 'aave-helpers/interfaces/IProposalGeneric
 contract AaveV3PolCapsPayload is IProposalGenericExecutor {
   address public constant WETH = AaveV3PolygonAssets.WETH_UNDERLYING;
   address public constant AAVE = AaveV3PolygonAssets.AAVE_UNDERLYING;
+  address public constant STMATIC = AaveV3PolygonAssets.stMATIC_UNDERLYING;
 
   uint256 public constant WETH_SUPPLY_CAP = 50_000;
   uint256 public constant AAVE_SUPPLY_CAP = 70_000;
+  uint256 public constant STMATIC_SUPPLY_CAP = 15_000_000;
 
   function execute() external {
     IPoolConfigurator configurator = AaveV3Polygon.POOL_CONFIGURATOR;
 
     configurator.setSupplyCap(WETH, WETH_SUPPLY_CAP);
     configurator.setSupplyCap(AAVE, AAVE_SUPPLY_CAP);
-
+    configurator.setSupplyCap(STMATIC, STMATIC_SUPPLY_CAP);
   }
 }

--- a/src/contracts/polygon/AaveV3PolCapsPayload-Feb26.sol
+++ b/src/contracts/polygon/AaveV3PolCapsPayload-Feb26.sol
@@ -8,6 +8,7 @@ import {IProposalGenericExecutor} from 'aave-helpers/interfaces/IProposalGeneric
 /**
  * @dev This payload sets supply caps for multiple assets on AAVE V3 Polygon
  * - Dicussion: https://governance.aave.com/t/arc-chaos-labs-supply-and-borrow-cap-updates-aave-v3-2023-02-24/12048
+ * - Discussion stMatic: https://governance.aave.com/t/arfc-increase-stmatic-supply-cap/12038
  */
 contract AaveV3PolCapsPayload is IProposalGenericExecutor {
   address public constant WETH = AaveV3PolygonAssets.WETH_UNDERLYING;

--- a/src/test/polygon/AaveV3PolCapsPayload-Feb26.t.sol
+++ b/src/test/polygon/AaveV3PolCapsPayload-Feb26.t.sol
@@ -9,7 +9,7 @@ import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/ProtocolV3TestBase
 import {AaveV3PolCapsPayload} from '../../contracts/polygon/AaveV3PolCapsPayload-Feb26.sol';
 import {TestWithExecutor} from 'aave-helpers/GovHelpers.sol';
 
-contract AaveV3PolFeb12CapsPayloadTest is ProtocolV3TestBase, TestWithExecutor {
+contract AaveV3PolFeb26CapsPayloadTest is ProtocolV3TestBase, TestWithExecutor {
   AaveV3PolCapsPayload public proposalPayload;
 
   address public constant WETH = AaveV3PolygonAssets.WETH_UNDERLYING;
@@ -46,5 +46,13 @@ contract AaveV3PolFeb12CapsPayloadTest is ProtocolV3TestBase, TestWithExecutor {
     ReserveConfig memory AAVEConfig = ProtocolV3TestBase._findReserveConfig(allConfigsBefore, AAVE);
     AAVEConfig.supplyCap = AAVE_SUPPLY_CAP;
     ProtocolV3TestBase._validateReserveConfig(AAVEConfig, allConfigsAfter);
+
+    //stMATIC
+    ReserveConfig memory STMATICConfig = ProtocolV3TestBase._findReserveConfig(
+      allConfigsBefore,
+      proposalPayload.STMATIC()
+    );
+    STMATICConfig.supplyCap = proposalPayload.STMATIC_SUPPLY_CAP();
+    ProtocolV3TestBase._validateReserveConfig(STMATICConfig, allConfigsAfter);
   }
 }


### PR DESCRIPTION
# Changelog

Add supply cap update to stMatic on v3 polygon.
Update tests to check for supply cap.

Forum post: https://governance.aave.com/t/arfc-increase-stmatic-supply-cap/12038