### PR TITLE
Aave V3 MaticX Supply Cap Increase and AGD Proposal

### DIFF
--- a/diffs/pre-Aave-V3-Polygon-Caps-Updates-20230503_post-Aave-V3-Polygon-Caps-Updates-20230503.md
+++ b/diffs/pre-Aave-V3-Polygon-Caps-Updates-20230503_post-Aave-V3-Polygon-Caps-Updates-20230503.md
@@ -1,0 +1,25 @@
+## Reserve changes
+
+### Reserves altered
+
+#### MaticX ([0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6](https://polygonscan.com/address/0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6))
+
+| description | value before | value after |
+| --- | --- | --- |
+| supplyCap | 17,200,000 MaticX | 29,300,000 MaticX |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0xfa68FB4628DFF1028CFEc22b4162FCcd0d45efb6": {
+      "supplyCap": {
+        "from": 17200000,
+        "to": 29300000
+      }
+    }
+  }
+}
+```

--- a/src/AaveV3ACIProposal_20230411/AaveV3ACIProposal_20230411.sol
+++ b/src/AaveV3ACIProposal_20230411/AaveV3ACIProposal_20230411.sol
@@ -14,8 +14,7 @@ import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethe
 contract AaveV3ACIProposal_20230411 is IProposalGenericExecutor {
   address public constant ACI_TREASURY = 0x57ab7ee15cE5ECacB1aB84EE42D5A9d0d8112922;
   address public constant AUSDT = AaveV2EthereumAssets.USDT_A_TOKEN;
-  address public constant COLLECTOR = AaveV2Ethereum.COLLECTOR;
-  address public constant RESERVE_CONTROLLER = AaveV2Ethereum.COLLECTOR_CONTROLLER;
+  address public constant COLLECTOR = address(AaveV2Ethereum.COLLECTOR);
   uint256 public constant STREAM_AMOUNT = 250000e6;
   uint256 public constant STREAM_DURATION = 180 days;
   uint256 public constant ACTUAL_STREAM_AMOUNT_A_USDT =

--- a/src/AaveV3ACIProposal_20230411/AaveV3ACIProposal_20230411Test.t.sol
+++ b/src/AaveV3ACIProposal_20230411/AaveV3ACIProposal_20230411Test.t.sol
@@ -19,10 +19,10 @@ contract AaveV3ACIProposal_20230411Test is TestWithExecutor {
   IERC20 public constant AUSDT = IERC20(0x3Ed3B47Dd13EC9a98b44e6204A523E766B225811);
 
   // 0x464
-  address public immutable AAVE_COLLECTOR = AaveV2Ethereum.COLLECTOR;
+  address public immutable AAVE_COLLECTOR = address(AaveV2Ethereum.COLLECTOR);
   address public constant ACI_TREASURY = 0x57ab7ee15cE5ECacB1aB84EE42D5A9d0d8112922;
 
-  IStreamable public immutable STREAMABLE_AAVE_COLLECTOR = IStreamable(AaveV2Ethereum.COLLECTOR);
+  IStreamable public immutable STREAMABLE_AAVE_COLLECTOR = IStreamable(address(AaveV2Ethereum.COLLECTOR));
 
   uint256 public constant STREAM_AMOUNT = 250_000 * 1e6;
   uint256 public constant STREAM_DURATION = 180 days;

--- a/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayload.sol
+++ b/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayload.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.19;
 import {IProposalGenericExecutor} from 'aave-helpers/interfaces/IProposalGenericExecutor.sol';
 import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
 
-contract AGDProposal is IProposalGenericExecutor {
+contract AaveV2EthAGDGrantsPayload is IProposalGenericExecutor {
 
   address public constant AGD_MULTISIG = 0x89C51828427F70D77875C6747759fB17Ba10Ceb0;
   address public constant aUSDTV1 = 0x71fc860F7D3A592A4a98740e39dB31d25db65ae8;

--- a/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayload.sol
+++ b/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayload.sol
@@ -4,6 +4,13 @@ pragma solidity 0.8.19;
 import {IProposalGenericExecutor} from 'aave-helpers/interfaces/IProposalGenericExecutor.sol';
 import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
 
+/**
+ * @title AaveV2EthAGDGrantsPayload
+ * @author Llama
+ * @dev Grant AGD approval to aUSDT v2 and revoke approval to aUSDT v1
+ * Forum: https://governance.aave.com/t/updated-proposal-aave-grants-dao-renewal/11289
+ * Communication: https://governance.aave.com/t/updated-proposal-aave-grants-dao-renewal/11289/9
+ */
 contract AaveV2EthAGDGrantsPayload is IProposalGenericExecutor {
 
   address public constant AGD_MULTISIG = 0x89C51828427F70D77875C6747759fB17Ba10Ceb0;

--- a/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayload.sol
+++ b/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayload.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IProposalGenericExecutor} from 'aave-helpers/interfaces/IProposalGenericExecutor.sol';
+import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+
+contract AGDProposal is IProposalGenericExecutor {
+
+  address public constant AGD_MULTISIG = 0x89C51828427F70D77875C6747759fB17Ba10Ceb0;
+  address public constant aUSDTV1 = 0x71fc860F7D3A592A4a98740e39dB31d25db65ae8;
+  uint256 public constant AMOUNT_AUSDT = 812_944_900000; // $812,944.90
+
+  function execute() external {
+    AaveV2Ethereum.COLLECTOR.approve(aUSDTV1, AGD_MULTISIG, 0);
+    AaveV2Ethereum.COLLECTOR.approve(AaveV2EthereumAssets.USDT_A_TOKEN, AGD_MULTISIG, AMOUNT_AUSDT);
+    }
+}

--- a/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayloadTest.t.sol
+++ b/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayloadTest.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {ProtocolV2TestBase} from 'aave-helpers/ProtocolV2TestBase.sol';
+import {AaveGovernanceV2} from 'aave-address-book/AaveGovernanceV2.sol';
+import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+import {TestWithExecutor} from 'aave-helpers/GovHelpers.sol';
+import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
+
+import {AGDProposal} from './AaveV2EthAGDGrantsPayload.sol';
+
+contract AGDProposalTest is ProtocolV2TestBase, TestWithExecutor {
+  AGDProposal payload;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 17180572);
+    _selectPayloadExecutor(AaveGovernanceV2.SHORT_EXECUTOR);
+
+    payload = new AGDProposal();
+  }
+
+  function test_execute() public {
+    // AGD Approvals Pre-Execution
+    assertEq(
+      IERC20(payload.aUSDTV1()).allowance(
+        address(AaveV2Ethereum.COLLECTOR),
+        payload.AGD_MULTISIG()
+      ),
+      payload.AMOUNT_AUSDT()
+    );
+    assertEq(
+      IERC20(AaveV2EthereumAssets.USDT_A_TOKEN).allowance(
+        address(AaveV2Ethereum.COLLECTOR),
+        payload.AGD_MULTISIG()
+      ),
+      0
+    );
+    // End AGD Approvals Pre-Execution
+
+    _executePayload(address(payload));
+
+    // AGD Approvals Post-Execution
+    assertEq(
+      IERC20(payload.aUSDTV1()).allowance(
+        address(AaveV2Ethereum.COLLECTOR),
+        payload.AGD_MULTISIG()
+      ),
+      0
+    );
+    assertEq(
+      IERC20(AaveV2EthereumAssets.USDT_A_TOKEN).allowance(
+        address(AaveV2Ethereum.COLLECTOR),
+        payload.AGD_MULTISIG()
+      ),
+      payload.AMOUNT_AUSDT()
+    );
+
+    vm.startPrank(payload.AGD_MULTISIG());
+    IERC20(AaveV2EthereumAssets.USDT_A_TOKEN).transferFrom(
+      address(AaveV2Ethereum.COLLECTOR),
+      makeAddr('new-addy'),
+      payload.AMOUNT_AUSDT()
+    );
+    vm.stopPrank();
+    // End AGD Approvals Post-Execution
+  }
+}

--- a/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayloadTest.t.sol
+++ b/src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayloadTest.t.sol
@@ -7,16 +7,16 @@ import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethe
 import {TestWithExecutor} from 'aave-helpers/GovHelpers.sol';
 import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
 
-import {AGDProposal} from './AaveV2EthAGDGrantsPayload.sol';
+import {AaveV2EthAGDGrantsPayload} from './AaveV2EthAGDGrantsPayload.sol';
 
-contract AGDProposalTest is ProtocolV2TestBase, TestWithExecutor {
-  AGDProposal payload;
+contract AaveV2EthAGDGrantsPayloadTest is ProtocolV2TestBase, TestWithExecutor {
+  AaveV2EthAGDGrantsPayload payload;
 
   function setUp() public {
     vm.createSelectFork(vm.rpcUrl('mainnet'), 17180572);
     _selectPayloadExecutor(AaveGovernanceV2.SHORT_EXECUTOR);
 
-    payload = new AGDProposal();
+    payload = new AaveV2EthAGDGrantsPayload();
   }
 
   function test_execute() public {

--- a/src/AaveV3CapsUpdates_20230503/AaveV3PolCapsUpdates_20230503_Payload.sol
+++ b/src/AaveV3CapsUpdates_20230503/AaveV3PolCapsUpdates_20230503_Payload.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.19;
+
+import {AaveV3PolygonAssets} from 'aave-address-book/AaveV3Polygon.sol';
+import {AaveV3PayloadPolygon, IEngine, EngineFlags} from 'aave-helpers/v3-config-engine/AaveV3PayloadPolygon.sol';
+
+/**
+ * @title AaveV3PolCapsUpdates_20230503_Payload
+ * @author Llama
+ * @dev Update the Aave V3 Polygon MaticX supply cap
+ * Forum: https://governance.aave.com/t/arfc-maticx-supply-cap-increase-polygon-v3/12657
+ * Snapshot: https://snapshot.org/#/aave.eth/proposal/0x7057a6311c791ebd57b93acb4a231dfd4fb92755fc02fa1de4723d0a5510d2ed
+ */
+contract AaveV3PolCapsUpdates_20230503_Payload is AaveV3PayloadPolygon {
+  uint256 public constant NEW_SUPPLY_CAP = 29_300_000;
+
+  function capsUpdates() public pure override returns (IEngine.CapsUpdate[] memory) {
+    IEngine.CapsUpdate[] memory capsUpdate = new IEngine.CapsUpdate[](1);
+
+    capsUpdate[0] = IEngine.CapsUpdate({
+      asset: AaveV3PolygonAssets.MaticX_UNDERLYING,
+      supplyCap: NEW_SUPPLY_CAP,
+      borrowCap: EngineFlags.KEEP_CURRENT
+    });
+
+    return capsUpdate;
+  }
+}

--- a/src/AaveV3CapsUpdates_20230503/AaveV3PolCapsUpdates_20230503_PayloadTest.t.sol
+++ b/src/AaveV3CapsUpdates_20230503/AaveV3PolCapsUpdates_20230503_PayloadTest.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.19;
+
+import {AaveV3Polygon, AaveV3PolygonAssets} from 'aave-address-book/AaveV3Polygon.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/ProtocolV3TestBase.sol';
+import {AaveGovernanceV2} from 'aave-address-book/AaveGovernanceV2.sol';
+import {TestWithExecutor} from 'aave-helpers/GovHelpers.sol';
+import {AaveV3PolCapsUpdates_20230503_Payload} from './AaveV3PolCapsUpdates_20230503_Payload.sol';
+
+contract AaveV3PolCapsUpdates_20230503_PayloadTest is ProtocolV3TestBase, TestWithExecutor {
+  AaveV3PolCapsUpdates_20230503_Payload payload;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('polygon'), 42257394);
+    _selectPayloadExecutor(AaveGovernanceV2.POLYGON_BRIDGE_EXECUTOR);
+
+    payload = new AaveV3PolCapsUpdates_20230503_Payload();
+  }
+
+  function testPoolActivation() public {
+    ReserveConfig[] memory allConfigsBefore = createConfigurationSnapshot(
+      'pre-Aave-V3-Polygon-Caps-Updates-20230503',
+      AaveV3Polygon.POOL
+    );
+
+    _executePayload(address(payload));
+
+    ReserveConfig memory MaticX = _findReserveConfig(
+      allConfigsBefore,
+      AaveV3PolygonAssets.MaticX_UNDERLYING
+    );
+
+    MaticX.supplyCap = payload.NEW_SUPPLY_CAP();
+
+    ReserveConfig[] memory allConfigsAfter = createConfigurationSnapshot(
+      'post-Aave-V3-Polygon-Caps-Updates-20230503',
+      AaveV3Polygon.POOL
+    );
+
+    address[] memory assetsChanged = new address[](1);
+    assetsChanged[0] = AaveV3PolygonAssets.MaticX_UNDERLYING;
+
+    _noReservesConfigsChangesApartFrom(allConfigsBefore, allConfigsAfter, assetsChanged);
+
+    _validateReserveConfig(MaticX, allConfigsAfter);
+
+    diffReports(
+      'pre-Aave-V3-Polygon-Caps-Updates-20230503',
+      'post-Aave-V3-Polygon-Caps-Updates-20230503'
+    );
+  }
+}

--- a/src/AaveV3CapsUpdates_20230503/DeployPayloads.s.sol
+++ b/src/AaveV3CapsUpdates_20230503/DeployPayloads.s.sol
@@ -22,14 +22,14 @@ contract DeployProposal is EthereumScript {
   function run() external broadcast {
     GovHelpers.Payload[] memory payloads = new GovHelpers.Payload[](2);
     payloads[0] = GovHelpers.buildMainnet(
-      address(0) // deployed AGD payload
+      0x7BE4FA90565d6fd6F7091d0af9E5a7F9CD7918A6
     );
     payloads[1] = GovHelpers.buildPolygon(
-      address(0) // deployed MaticX payload
+      0x22C669EEDf6e58De81777692B070CDB7432A4F84
     );
     GovHelpers.createProposal(
       payloads,
-      0 // TODO: Replace with actual hash
+      0xa3267468b4d12df2ded6b48eea658134acfb9e512b2b34ca9299fde49062531f
     );
   }
 }

--- a/src/AaveV3CapsUpdates_20230503/DeployPayloads.s.sol
+++ b/src/AaveV3CapsUpdates_20230503/DeployPayloads.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+import {EthereumScript} from 'aave-helpers/ScriptUtils.sol';
+import {PolygonScript} from 'aave-helpers/ScriptUtils.sol';
+import {GovHelpers} from 'aave-helpers/GovHelpers.sol';
+import {AaveV3PolCapsUpdates_20230503_Payload} from 'src/AaveV3CapsUpdates_20230503/AaveV3PolCapsUpdates_20230503_Payload.sol';
+import {AaveV2EthAGDGrantsPayload} from 'src/AaveV3CapsUpdates_20230503/AaveV2EthAGDGrantsPayload.sol';
+
+contract DeployPolygonPayload is PolygonScript {
+  function run() external broadcast {
+    new AaveV3PolCapsUpdates_20230503_Payload();
+  }
+}
+
+contract DeployMainnetPayload is EthereumScript {
+  function run() external broadcast {
+    new AaveV2EthAGDGrantsPayload();
+  }
+}
+
+contract DeployProposal is EthereumScript {
+  function run() external broadcast {
+    GovHelpers.Payload[] memory payloads = new GovHelpers.Payload[](2);
+    payloads[0] = GovHelpers.buildMainnet(
+      address(0) // deployed AGD payload
+    );
+    payloads[1] = GovHelpers.buildPolygon(
+      address(0) // deployed MaticX payload
+    );
+    GovHelpers.createProposal(
+      payloads,
+      0 // TODO: Replace with actual hash
+    );
+  }
+}


### PR DESCRIPTION
# Changelog

Add MaticX supply cap increase for Aave v3 polygon.
Add AGD approval.
Add tests
Add diff file.

# Note

AGD approval was done incorrectly here: https://github.com/llamaxyz/aave-proposals/blob/main/src/proposals/aave-grants-dao-renewal/ProposalPayload.sol#L19
as the aUSDT token used was incorrect.

We are revoking that approval and approving v2 of the token.