### PR TITLE
fix: generator protocol version typo

### DIFF
--- a/generator/common.js
+++ b/generator/common.js
@@ -20,7 +20,7 @@ export function getDate() {
 }
 
 export function generateName(options) {
-  return `${options.protocolVersion === "v2" ? "AaveV2" : "AaveV3"}_${
+  return `${options.protocolVersion === "V2" ? "AaveV2" : "AaveV3"}_${
     options.chains.length === 1 ? SHORT_CHAINS[options.chains[0]] : "Multi"
   }_${options.name}_${getDate()}`;
 }


### PR DESCRIPTION
Generator CLI expects "V2" while name generator checks for "v2"