### PR TITLE
Add v2 deprecation AIP

### DIFF
--- a/diffs/preTestEthereumUpdate20231009_postTestEthereumUpdate20231009.md
+++ b/diffs/preTestEthereumUpdate20231009_postTestEthereumUpdate20231009.md
@@ -28,6 +28,7 @@
 | description | value before | value after |
 | --- | --- | --- |
 | ltv | 30 % | 0 % |
+| liquidationThreshold | 40 % | 24 % |
 
 
 #### DPI ([0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b](https://etherscan.io/address/0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b))
@@ -149,6 +150,10 @@
       }
     },
     "0x111111111117dC0aa78b770fA6A738034120C302": {
+      "liquidationThreshold": {
+        "from": 4000,
+        "to": 2400
+      },
       "ltv": {
         "from": 3000,
         "to": 0

--- a/diffs/preTestEthereumUpdate20231009_postTestEthereumUpdate20231009.md
+++ b/diffs/preTestEthereumUpdate20231009_postTestEthereumUpdate20231009.md
@@ -1,0 +1,253 @@
+## Reserve changes
+
+### Reserve altered
+
+#### BAT ([0x0D8775F648430679A709E98d2b0Cb6250d2887EF](https://etherscan.io/address/0x0D8775F648430679A709E98d2b0Cb6250d2887EF))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 40 % | 1 % |
+
+
+#### MANA ([0x0F5D2fB29fb7d3CFeE444a200298f468908cC942](https://etherscan.io/address/0x0F5D2fB29fb7d3CFeE444a200298f468908cC942))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 54 % | 48 % |
+
+
+#### YFI ([0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e](https://etherscan.io/address/0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 50 % | 45 % |
+
+
+#### 1INCH ([0x111111111117dC0aa78b770fA6A738034120C302](https://etherscan.io/address/0x111111111117dC0aa78b770fA6A738034120C302))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 30 % | 0 % |
+
+
+#### DPI ([0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b](https://etherscan.io/address/0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 42 % | 16 % |
+
+
+#### UNI ([0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984](https://etherscan.io/address/0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 58 % | 0 % |
+
+
+#### REN ([0x408e41876cCCDC0F92210600ef50372656052a38](https://etherscan.io/address/0x408e41876cCCDC0F92210600ef50372656052a38))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 32 % | 27 % |
+
+
+#### CVX ([0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B](https://etherscan.io/address/0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 35 % | 33 % |
+
+
+#### LINK ([0x514910771AF9Ca656af840dff83E8264EcF986CA](https://etherscan.io/address/0x514910771AF9Ca656af840dff83E8264EcF986CA))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 70 % | 0 % |
+| liquidationThreshold | 83 % | 82 % |
+
+
+#### xSUSHI ([0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272](https://etherscan.io/address/0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 57 % | 28 % |
+
+
+#### MKR ([0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2](https://etherscan.io/address/0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 45 % | 0 % |
+| liquidationThreshold | 50 % | 35 % |
+
+
+#### SNX ([0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F](https://etherscan.io/address/0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 36 % | 0 % |
+| liquidationThreshold | 49 % | 43 % |
+
+
+#### ENS ([0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72](https://etherscan.io/address/0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72))
+
+| description | value before | value after |
+| --- | --- | --- |
+| ltv | 42 % | 0 % |
+| liquidationThreshold | 52 % | 50 % |
+
+
+#### CRV ([0xD533a949740bb3306d119CC777fa900bA034cd52](https://etherscan.io/address/0xD533a949740bb3306d119CC777fa900bA034cd52))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 45 % | 42 % |
+
+
+#### ZRX ([0xE41d2489571d322189246DaFA5ebDe1F4699F498](https://etherscan.io/address/0xE41d2489571d322189246DaFA5ebDe1F4699F498))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 42 % | 37 % |
+
+
+#### ENJ ([0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c](https://etherscan.io/address/0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 52 % | 50 % |
+
+
+#### BAL ([0xba100000625a3754423978a60c9317c58a424e3D](https://etherscan.io/address/0xba100000625a3754423978a60c9317c58a424e3D))
+
+| description | value before | value after |
+| --- | --- | --- |
+| liquidationThreshold | 35 % | 25 % |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x0D8775F648430679A709E98d2b0Cb6250d2887EF": {
+      "liquidationThreshold": {
+        "from": 4000,
+        "to": 100
+      }
+    },
+    "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942": {
+      "liquidationThreshold": {
+        "from": 5400,
+        "to": 4800
+      }
+    },
+    "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e": {
+      "liquidationThreshold": {
+        "from": 5000,
+        "to": 4500
+      }
+    },
+    "0x111111111117dC0aa78b770fA6A738034120C302": {
+      "ltv": {
+        "from": 3000,
+        "to": 0
+      }
+    },
+    "0x1494CA1F11D487c2bBe4543E90080AeBa4BA3C2b": {
+      "liquidationThreshold": {
+        "from": 4200,
+        "to": 1600
+      }
+    },
+    "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984": {
+      "ltv": {
+        "from": 5800,
+        "to": 0
+      }
+    },
+    "0x408e41876cCCDC0F92210600ef50372656052a38": {
+      "liquidationThreshold": {
+        "from": 3200,
+        "to": 2700
+      }
+    },
+    "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B": {
+      "liquidationThreshold": {
+        "from": 3500,
+        "to": 3300
+      }
+    },
+    "0x514910771AF9Ca656af840dff83E8264EcF986CA": {
+      "liquidationThreshold": {
+        "from": 8300,
+        "to": 8200
+      },
+      "ltv": {
+        "from": 7000,
+        "to": 0
+      }
+    },
+    "0x8798249c2E607446EfB7Ad49eC89dD1865Ff4272": {
+      "liquidationThreshold": {
+        "from": 5700,
+        "to": 2800
+      }
+    },
+    "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2": {
+      "liquidationThreshold": {
+        "from": 5000,
+        "to": 3500
+      },
+      "ltv": {
+        "from": 4500,
+        "to": 0
+      }
+    },
+    "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F": {
+      "liquidationThreshold": {
+        "from": 4900,
+        "to": 4300
+      },
+      "ltv": {
+        "from": 3600,
+        "to": 0
+      }
+    },
+    "0xC18360217D8F7Ab5e7c516566761Ea12Ce7F9D72": {
+      "liquidationThreshold": {
+        "from": 5200,
+        "to": 5000
+      },
+      "ltv": {
+        "from": 4200,
+        "to": 0
+      }
+    },
+    "0xD533a949740bb3306d119CC777fa900bA034cd52": {
+      "liquidationThreshold": {
+        "from": 4500,
+        "to": 4200
+      }
+    },
+    "0xE41d2489571d322189246DaFA5ebDe1F4699F498": {
+      "liquidationThreshold": {
+        "from": 4200,
+        "to": 3700
+      }
+    },
+    "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c": {
+      "liquidationThreshold": {
+        "from": 5200,
+        "to": 5000
+      }
+    },
+    "0xba100000625a3754423978a60c9317c58a424e3D": {
+      "liquidationThreshold": {
+        "from": 3500,
+        "to": 2500
+      }
+    }
+  }
+}
+```

--- a/src/AaveV2Update_20231009/AaveV2Ethereum_20231009.sol
+++ b/src/AaveV2Update_20231009/AaveV2Ethereum_20231009.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IEngine, EngineFlags} from 'aave-helpers/v2-config-engine/AaveV2PayloadBase.sol';
+import {AaveV2PayloadEthereum} from 'aave-helpers/v2-config-engine/AaveV2PayloadEthereum.sol';
+import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+
+/**
+ * @title v2 Deprecation Plan, 2023.10.03
+ * @author Gauntlet, Chaos Labs
+ * - Discussion: https://governance.aave.com/t/arfc-v2-ethereum-deprecation-10-03-2023/15040
+ */
+contract AaveV2EthereumUpdate20231009Payload is AaveV2PayloadEthereum {
+  function _postExecute() internal override {
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.ONE_INCH_UNDERLYING,
+      0,
+      4000,
+      10850
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.BAL_UNDERLYING,
+      0,
+      2500,
+      10800
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.BAT_UNDERLYING,
+      0,
+      100,
+      11000
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.CRV_UNDERLYING,
+      0,
+      4200,
+      10800
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.CVX_UNDERLYING,
+      0,
+      3300,
+      10850
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.DPI_UNDERLYING,
+      0,
+      1600,
+      11000
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.ENJ_UNDERLYING,
+      0,
+      5000,
+      11000
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.LINK_UNDERLYING,
+      0,
+      8200,
+      10700
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.MANA_UNDERLYING,
+      0,
+      4800,
+      11000
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.MKR_UNDERLYING,
+      0,
+      3500,
+      10750
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.REN_UNDERLYING,
+      0,
+      2700,
+      11000
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.SNX_UNDERLYING,
+      0,
+      4300,
+      10750
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.YFI_UNDERLYING,
+      0,
+      4500,
+      11000
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.ZRX_UNDERLYING,
+      0,
+      3700,
+      11000
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.xSUSHI_UNDERLYING,
+      0,
+      2800,
+      11000
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.ENS_UNDERLYING,
+      0,
+      5000,
+      10800
+    );
+
+    AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
+      AaveV2EthereumAssets.UNI_UNDERLYING,
+      0,
+      7000,
+      10900
+    );
+  }
+}

--- a/src/AaveV2Update_20231009/AaveV2Ethereum_20231009.sol
+++ b/src/AaveV2Update_20231009/AaveV2Ethereum_20231009.sol
@@ -15,7 +15,7 @@ contract AaveV2EthereumUpdate20231009Payload is AaveV2PayloadEthereum {
     AaveV2Ethereum.POOL_CONFIGURATOR.configureReserveAsCollateral(
       AaveV2EthereumAssets.ONE_INCH_UNDERLYING,
       0,
-      4000,
+      2400,
       10850
     );
 

--- a/src/AaveV2Update_20231009/AaveV2Update_20231009.md
+++ b/src/AaveV2Update_20231009/AaveV2Update_20231009.md
@@ -13,7 +13,7 @@ Following the [v2 deprecation framework](https://governance.aave.com/t/arfc-aave
 
 | Asset  | Current LT | Rec LT | Current LTV | Rec LTV |
 |--------|--------|--------|-------------|---------|
-| 1INCH  | 40%    | 40%    | 30%         | 0       |
+| 1INCH  | 40%    | 24%    | 30%         | 0       |
 | BAL    | 35%    | 25%    | 0           | 0       |
 | BAT    | 40%    | 1%     | 0           | 0       |
 | CRV    | 45%    | 42%    | 0           | 0       |
@@ -36,6 +36,7 @@ Following the [v2 deprecation framework](https://governance.aave.com/t/arfc-aave
 
 The proposal implements changes using the following payloads:
   - [Ethereum](https://github.com/bgd-labs/aave-proposals/blob/main/src/AaveV2Update_20231009/AaveV2Ethereum_20231009.sol)
+  - [Ethereum Tests](https://github.com/bgd-labs/aave-proposals/blob/main/src/AaveV2Update_20231009/AaveV2Update_20231009_Test.t.sol)
 
 ## References
 
@@ -44,8 +45,6 @@ The proposal implements changes using the following payloads:
 ## Disclaimer
 
 Gauntlet and Chaos have not received any compensation from any third-party in exchange for recommending any of the actions contained in this proposal.
-
-By approving this proposal, you agree that any services provided by Gauntlet shall be governed by the terms of service available at gauntlet.network/tos.
 
 ## Copyright
 

--- a/src/AaveV2Update_20231009/AaveV2Update_20231009.md
+++ b/src/AaveV2Update_20231009/AaveV2Update_20231009.md
@@ -35,7 +35,7 @@ Following the [v2 deprecation framework](https://governance.aave.com/t/arfc-aave
 ## Implementation
 
 The proposal implements changes using the following payloads:
-  - [Ethereum]()
+  - [Ethereum](https://github.com/bgd-labs/aave-proposals/blob/main/src/AaveV2Update_20231009/AaveV2Ethereum_20231009.sol)
 
 ## References
 

--- a/src/AaveV2Update_20231009/AaveV2Update_20231009.md
+++ b/src/AaveV2Update_20231009/AaveV2Update_20231009.md
@@ -1,0 +1,54 @@
+---
+title: v2 Deprecation Plan, 2023.10.03
+author: Gauntlet, Chaos Labs
+discussions: https://governance.aave.com/t/arfc-v2-ethereum-deprecation-10-03-2023/15040
+---
+
+## Summary
+
+Following the [v2 deprecation framework](https://governance.aave.com/t/arfc-aave-v2-markets-deprecation-plan/14870), Gauntlet and Chaos recommend the following parameter changes to frozen assets on Aave v2 Ethereum.
+
+
+## Specification
+
+| Asset  | Current LT | Rec LT | Current LTV | Rec LTV |
+|--------|--------|--------|-------------|---------|
+| 1INCH  | 40%    | 40%    | 30%         | 0       |
+| BAL    | 35%    | 25%    | 0           | 0       |
+| BAT    | 40%    | 1%     | 0           | 0       |
+| CRV    | 45%    | 42%    | 0           | 0       |
+| CVX    | 35%    | 33%    | 0           | 0       |
+| DPI    | 42%    | 16%    | 0           | 0       |
+| ENJ    | 52%    | 50%    | 0           | 0       |
+| ENS    | 52%    | 50%    | 42%         | 0       |
+| LINK   | 83%    | 82%    | 70%         | 0       |
+| MANA   | 54%    | 48%    | 0           | 0       |
+| MKR    | 50%    | 35%    | 45%         | 0       |
+| REN    | 32%    | 27%    | 0           | 0       |
+| SNX    | 49%    | 43%    | 36%         | 0       |
+| UNI    | 70%    | 70%    | 58%         | 0       |
+| xSUSHI | 57%    | 28%    | 0           | 0       |
+| YFI    | 50%    | 45%    | 0           | 0       |
+| ZRX    | 42%    | 37%    | 0           | 0       |
+
+
+## Implementation
+
+The proposal implements changes using the following payloads:
+  - [Ethereum]()
+
+## References
+
+- **Discussion**: https://governance.aave.com/t/arfc-v2-ethereum-deprecation-10-03-2023/15040
+
+## Disclaimer
+
+Gauntlet and Chaos have not received any compensation from any third-party in exchange for recommending any of the actions contained in this proposal.
+
+By approving this proposal, you agree that any services provided by Gauntlet shall be governed by the terms of service available at gauntlet.network/tos.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+*By approving this proposal, you agree that any services provided by Gauntlet shall be governed by the terms of service available at gauntlet.network/tos.*

--- a/src/AaveV2Update_20231009/AaveV2Update_20231009_Test.t.sol
+++ b/src/AaveV2Update_20231009/AaveV2Update_20231009_Test.t.sol
@@ -62,6 +62,7 @@ contract AaveV2EthereumUpdate_20231009_Test is ProtocolV2TestBase {
         AaveV2EthereumAssets.ONE_INCH_UNDERLYING
       );
       ONE_INCH_UNDERLYING_CONFIG.ltv = 0;
+      ONE_INCH_UNDERLYING_CONFIG.liquidationThreshold = 24_00;
       _validateReserveConfig(ONE_INCH_UNDERLYING_CONFIG, allConfigsAfter);
 
       ReserveConfig memory BAL_UNDERLYING_CONFIG = _findReserveConfig(

--- a/src/AaveV2Update_20231009/AaveV2Update_20231009_Test.t.sol
+++ b/src/AaveV2Update_20231009/AaveV2Update_20231009_Test.t.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import 'forge-std/Test.sol';
+import {AaveGovernanceV2} from 'aave-address-book/AaveGovernanceV2.sol';
+import {ProtocolV2TestBase, ReserveConfig} from 'aave-helpers/ProtocolV2TestBase.sol';
+import {GovHelpers} from 'aave-helpers/GovHelpers.sol';
+import {AaveV2EthereumUpdate20231009Payload} from './AaveV2Ethereum_20231009.sol';
+import {IEngine, EngineFlags} from 'aave-helpers/v2-config-engine/AaveV2PayloadBase.sol';
+import {AaveV2PayloadEthereum} from 'aave-helpers/v2-config-engine/AaveV2PayloadEthereum.sol';
+import {AaveV2Ethereum, AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+
+contract AaveV2EthereumUpdate_20231009_Test is ProtocolV2TestBase {
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 18316091);
+  }
+
+  function testEthereum20231009UpdatePayload() public {
+    ReserveConfig[] memory allConfigsBefore = createConfigurationSnapshot(
+      'preTestEthereumUpdate20231009',
+      AaveV2Ethereum.POOL
+    );
+
+    GovHelpers.executePayload(
+      vm,
+      address(new AaveV2EthereumUpdate20231009Payload()),
+      AaveGovernanceV2.SHORT_EXECUTOR
+    );
+
+    ReserveConfig[] memory allConfigsAfter = createConfigurationSnapshot(
+      'postTestEthereumUpdate20231009',
+      AaveV2Ethereum.POOL
+    );
+
+    diffReports('preTestEthereumUpdate20231009', 'postTestEthereumUpdate20231009');
+
+    address[] memory assetsChanged = new address[](17);
+
+    assetsChanged[0] = AaveV2EthereumAssets.ONE_INCH_UNDERLYING;
+    assetsChanged[1] = AaveV2EthereumAssets.BAL_UNDERLYING;
+    assetsChanged[2] = AaveV2EthereumAssets.BAT_UNDERLYING;
+    assetsChanged[3] = AaveV2EthereumAssets.CRV_UNDERLYING;
+    assetsChanged[4] = AaveV2EthereumAssets.CVX_UNDERLYING;
+    assetsChanged[5] = AaveV2EthereumAssets.DPI_UNDERLYING;
+    assetsChanged[6] = AaveV2EthereumAssets.ENJ_UNDERLYING;
+    assetsChanged[7] = AaveV2EthereumAssets.LINK_UNDERLYING;
+    assetsChanged[8] = AaveV2EthereumAssets.MANA_UNDERLYING;
+    assetsChanged[9] = AaveV2EthereumAssets.MKR_UNDERLYING;
+    assetsChanged[10] = AaveV2EthereumAssets.REN_UNDERLYING;
+    assetsChanged[11] = AaveV2EthereumAssets.SNX_UNDERLYING;
+    assetsChanged[12] = AaveV2EthereumAssets.YFI_UNDERLYING;
+    assetsChanged[13] = AaveV2EthereumAssets.ZRX_UNDERLYING;
+    assetsChanged[14] = AaveV2EthereumAssets.xSUSHI_UNDERLYING;
+    assetsChanged[15] = AaveV2EthereumAssets.ENS_UNDERLYING;
+    assetsChanged[16] = AaveV2EthereumAssets.UNI_UNDERLYING;
+
+    _noReservesConfigsChangesApartFrom(allConfigsBefore, allConfigsAfter, assetsChanged);
+
+    {
+      ReserveConfig memory ONE_INCH_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.ONE_INCH_UNDERLYING
+      );
+      ONE_INCH_UNDERLYING_CONFIG.ltv = 0;
+      _validateReserveConfig(ONE_INCH_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory BAL_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.BAL_UNDERLYING
+      );
+      BAL_UNDERLYING_CONFIG.liquidationThreshold = 25_00;
+      _validateReserveConfig(BAL_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory BAT_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.BAT_UNDERLYING
+      );
+      BAT_UNDERLYING_CONFIG.liquidationThreshold = 1_00;
+      _validateReserveConfig(BAT_UNDERLYING_CONFIG, allConfigsAfter);
+    }
+
+    {
+      ReserveConfig memory CRV_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.CRV_UNDERLYING
+      );
+      CRV_UNDERLYING_CONFIG.liquidationThreshold = 42_00;
+      _validateReserveConfig(CRV_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory CVX_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.CVX_UNDERLYING
+      );
+      CVX_UNDERLYING_CONFIG.liquidationThreshold = 33_00;
+      _validateReserveConfig(CVX_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory DPI_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.DPI_UNDERLYING
+      );
+      DPI_UNDERLYING_CONFIG.liquidationThreshold = 16_00;
+      _validateReserveConfig(DPI_UNDERLYING_CONFIG, allConfigsAfter);
+    }
+
+    {
+      ReserveConfig memory ENJ_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.ENJ_UNDERLYING
+      );
+      ENJ_UNDERLYING_CONFIG.liquidationThreshold = 50_00;
+      _validateReserveConfig(ENJ_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory ENS_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.ENS_UNDERLYING
+      );
+      ENS_UNDERLYING_CONFIG.liquidationThreshold = 50_00;
+      ENS_UNDERLYING_CONFIG.ltv = 0;
+      _validateReserveConfig(ENS_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory LINK_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.LINK_UNDERLYING
+      );
+      LINK_UNDERLYING_CONFIG.liquidationThreshold = 82_00;
+      LINK_UNDERLYING_CONFIG.ltv = 0;
+      _validateReserveConfig(LINK_UNDERLYING_CONFIG, allConfigsAfter);
+    }
+
+    {
+      ReserveConfig memory MANA_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.MANA_UNDERLYING
+      );
+      MANA_UNDERLYING_CONFIG.liquidationThreshold = 48_00;
+      _validateReserveConfig(MANA_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory MKR_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.MKR_UNDERLYING
+      );
+      MKR_UNDERLYING_CONFIG.liquidationThreshold = 35_00;
+      MKR_UNDERLYING_CONFIG.ltv = 0;
+      _validateReserveConfig(MKR_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory REN_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.REN_UNDERLYING
+      );
+      REN_UNDERLYING_CONFIG.liquidationThreshold = 27_00;
+      _validateReserveConfig(REN_UNDERLYING_CONFIG, allConfigsAfter);
+    }
+
+    {
+      ReserveConfig memory SNX_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.SNX_UNDERLYING
+      );
+      SNX_UNDERLYING_CONFIG.liquidationThreshold = 43_00;
+      SNX_UNDERLYING_CONFIG.ltv = 0;
+      _validateReserveConfig(SNX_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory UNI_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.UNI_UNDERLYING
+      );
+      UNI_UNDERLYING_CONFIG.ltv = 0;
+      _validateReserveConfig(UNI_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory xSUSHI_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.xSUSHI_UNDERLYING
+      );
+      xSUSHI_UNDERLYING_CONFIG.liquidationThreshold = 28_00;
+      _validateReserveConfig(xSUSHI_UNDERLYING_CONFIG, allConfigsAfter);
+    }
+
+    {
+      ReserveConfig memory YFI_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.YFI_UNDERLYING
+      );
+      YFI_UNDERLYING_CONFIG.liquidationThreshold = 45_00;
+      _validateReserveConfig(YFI_UNDERLYING_CONFIG, allConfigsAfter);
+
+      ReserveConfig memory ZRX_UNDERLYING_CONFIG = _findReserveConfig(
+        allConfigsBefore,
+        AaveV2EthereumAssets.ZRX_UNDERLYING
+      );
+      ZRX_UNDERLYING_CONFIG.liquidationThreshold = 37_00;
+      _validateReserveConfig(ZRX_UNDERLYING_CONFIG, allConfigsAfter);
+    }
+    e2eTest(AaveV2Ethereum.POOL);
+  }
+}

--- a/src/AaveV2Update_20231009/DeployAaveV2Update_20231009.s.sol
+++ b/src/AaveV2Update_20231009/DeployAaveV2Update_20231009.s.sol
@@ -12,7 +12,7 @@ import {
 contract CreateProposal is EthereumScript {
   function run() external broadcast {
     GovHelpers.Payload[] memory payloads = new GovHelpers.Payload[](1);
-    payloads[0] = GovHelpers.buildMainnet(address(0));
+    payloads[0] = GovHelpers.buildMainnet(0xff374aD1be52fF54Cf576586253a113d3F48D4B7);
     GovHelpers.createProposal(
       payloads,
       GovHelpers.ipfsHashFile(

--- a/src/AaveV2Update_20231009/DeployAaveV2Update_20231009.s.sol
+++ b/src/AaveV2Update_20231009/DeployAaveV2Update_20231009.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovHelpers} from 'aave-helpers/GovHelpers.sol';
+import {
+  EthereumScript
+} from 'aave-helpers/ScriptUtils.sol';
+import {
+  AaveV2EthereumUpdate20231009Payload
+} from './AaveV2Ethereum_20231009.sol';
+
+contract CreateProposal is EthereumScript {
+  function run() external broadcast {
+    GovHelpers.Payload[] memory payloads = new GovHelpers.Payload[](1);
+    payloads[0] = GovHelpers.buildMainnet(address(0));
+    GovHelpers.createProposal(
+      payloads,
+      GovHelpers.ipfsHashFile(
+        vm,
+        'src/AaveV2Update_20231009/AaveV2Update_20231009.md'
+      )
+    );
+  }
+}
+
+contract Deploy20231009PayloadEthereum is EthereumScript {
+  function run() external broadcast {
+    new AaveV2EthereumUpdate20231009Payload();
+  }
+}


### PR DESCRIPTION
In accordance with https://governance.aave.com/t/arfc-v2-ethereum-deprecation-10-03-2023/15040